### PR TITLE
Added symlink notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ clevis init
 npm i
 ```
 
+If the symlink hasn't been created for you, navigate to src and create one:
+
+```
+cd src
+ln -s ../contracts .
+cd ../
+```
+
 Then compile, deploy, and publish the contracts:
 ```
 clevis test full


### PR DESCRIPTION
No matter what I do, whenever I clone the repo and run the commands in the order specified in the README, I cannot publish the contracts by doing `clevis test full` because there's no "contracts" folder.